### PR TITLE
Inlines external github action

### DIFF
--- a/.github/workflows/dependabot-test.yml
+++ b/.github/workflows/dependabot-test.yml
@@ -1,0 +1,29 @@
+name: dependabot-pr-merge
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        description: "The PR number"
+        required: true
+        type: string
+
+jobs:
+  automerge:
+    name: Merge Dependabot Pull Pequest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Merge
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            var pr_number = ${{ inputs.pr_number }}
+            github.rest.pulls.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr_number,
+              merge_method: 'squash'
+            })

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,6 +28,6 @@ jobs:
   call-dependabot-pr-workflow:
     needs: test
     if: ${{ success() && github.actor == 'dependabot[bot]' }}
-    uses: pivotal-cf/brokerapi/.github/workflows/dependabot-test.yml@main
+    uses: ./.github/workflows/dependabot-test.yml
     with:
       pr_number: ${{ github.event.number }}


### PR DESCRIPTION
This repo was referencing a shared action in the broker API repo, but that's in the cloudfoundry org

Creates a local copy of this file so we can run the action.

Derived from work done in pivotal-cf/on-demand-service-broker@63cdc301956868e18334f0fe950295b9392ef49d